### PR TITLE
Allow building data_image behind proxy

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -40,6 +40,8 @@ module Kitchen
       default_config :chef_image, 'chef/chef'
       default_config :chef_version, 'latest'
       default_config :data_image, 'dokken/kitchen-cache:latest'
+      default_config :data_image_registry, 'docker.io'
+      default_config :data_intermediate_instructions, []
       default_config :dns, nil
       default_config :dns_search, nil
       default_config :docker_info, docker_info

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -61,9 +61,12 @@ X8N2N9ZNnORJqK374yGj1jWUU66mQhPvn49QpG8P2HEoh2RQjNvyHA==
 
     def data_dockerfile
       <<-EOF
-FROM centos:7
+FROM #{config[:data_image_registry]}/centos:7
 MAINTAINER Sean OMeara \"sean@sean.io\"
 ENV LANG en_US.UTF-8
+#{Array(config[:data_intermediate_instructions]).each do |instruction|
+  instruction
+end.join("\n")}
 
 RUN yum -y install tar rsync openssh-server passwd git
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''


### PR DESCRIPTION
Addresses #147

**User Story**
As a build engineer,
I want to use kitchen-dokken behind a proxy without direct access to the
  internet,
So that it may be used in corporate CI/CD pipelines.

**Test Case**
*GIVEN* instance executing kitchen does not have direct internet access
*WHEN* performing integration testing with kitchen-dokken
*EXPECT* the ability to pull Docker images via proxy
*EXPECT* the ability to control proxy access while building the baked-in
  data_image

Maybe not the best approach, but it provides the minimum flexibility needed to
perform testing in an environment with strict access control.