### PR TITLE
Private registry auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,24 +447,27 @@ provisioner:
 ```
 
 ### Docker Credentials
-￼
-￼You can set credentials for pulling images from private docker registries in a json file.
-￼```json
-￼{
-￼  "username": "myusername",
-￼  "password": "mypassword",
-￼  "email": "myemail@mydomain",
-￼  "serveraddress": "https://index.docker.io/v1/"
-￼}
-￼```
-￼
-￼Then add the `creds_file` driver configuration option.
-￼```yaml
-￼platforms:
-￼- name: ubuntu-16.04
-￼  driver:
-￼    image: myorg/private-ubuntu-16.04
-￼    creds_file: './config.json'
+
+You can set an array of credentials for pulling images from private docker registries in a json file.
+```json
+[
+  {
+    "username": "myusername",
+    "password": "mypassword",
+    "email": "myemail@mydomain",
+    "serveraddress": "https://index.docker.io/v1/"
+  }
+]
+```
+
+Then add the `creds_file` driver configuration option.
+```yaml
+platforms:
+  - name: ubuntu-16.04
+    driver:
+      image: myorg/private-ubuntu-16.04
+      creds_file: './config.json'
+```
 
 ### Using dokken-images
 

--- a/README.md
+++ b/README.md
@@ -446,6 +446,26 @@ provisioner:
   clean_dokken_sandbox: false
 ```
 
+### Docker Credentials
+￼
+￼You can set credentials for pulling images from private docker registries in a json file.
+￼```json
+￼{
+￼  "username": "myusername",
+￼  "password": "mypassword",
+￼  "email": "myemail@mydomain",
+￼  "serveraddress": "https://index.docker.io/v1/"
+￼}
+￼```
+￼
+￼Then add the `creds_file` driver configuration option.
+￼```yaml
+￼platforms:
+￼- name: ubuntu-16.04
+￼  driver:
+￼    image: myorg/private-ubuntu-16.04
+￼    creds_file: './config.json'
+
 ### Using dokken-images
 
 While the `intermediate_instructions` directive is a fine hack around the


### PR DESCRIPTION
Based on @hortoncd's work from #150 

I made it take an array of auth so you can do things like quay.io and ECR and still use the standard chef images from docker hub.