### PR TITLE
Remove embedded from chef-client path

### DIFF
--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -30,7 +30,7 @@ module Kitchen
       plugin_version Kitchen::VERSION
 
       default_config :root_path, '/opt/kitchen'
-      default_config :chef_binary, '/opt/chef/embedded/bin/chef-client'
+      default_config :chef_binary, '/opt/chef/bin/chef-client'
       default_config :chef_options, ' -z'
       default_config :chef_log_level, 'warn'
       default_config :chef_output_format, 'doc'


### PR DESCRIPTION
This is bypassing the binstubs and breaking our tests in
buildkite.
