### PR TITLE
Create option for leaving the kitchen sandbox between converges

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,17 @@ platforms:
       - RUN rm /etc/apt/apt.conf.d/docker-clean
 ```
 
+### Chef cache
+
+When chef converges `kitchen-dokken` populates `/opt/kitchen/` with the chef and test kitchen data required to converge. By default this directory is cleared out at the end of every run. One of the subdirectories of `/opt/kitchen/` is the chef cache directory. For cookbooks that download significant amounts of data from the network, i.e. many `remote_file` calls, this can make subsequent converges unnecessarily slow.  
+If you would like the chef cache to be preserved between converges add `clean_dokken_sandbox: false` to the provisioner section of `kitchen.yml`. The default value is true. 
+
+```
+provisioner:
+  name: dokken
+  clean_dokken_sandbox: false
+```
+
 ### Using dokken-images
 
 While the `intermediate_instructions` directive is a fine hack around the

--- a/lib/kitchen/driver/dokken_version.rb
+++ b/lib/kitchen/driver/dokken_version.rb
@@ -18,6 +18,6 @@
 module Kitchen
   module Driver
     # Version string for Dokken Kitchen driver
-    DOKKEN_VERSION = '2.8.2'.freeze
+    DOKKEN_VERSION = '2.8.3'.freeze
   end
 end

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -50,6 +50,7 @@ module Kitchen
         driver = provisioner.instance.driver
         driver[:chef_version]
       end
+      default_config :clean_dokken_sandbox, true
 
       # (see Base#call)
       def call(state)
@@ -71,6 +72,7 @@ module Kitchen
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message
       ensure
+        return unless config[:clean_dokken_sandbox]
         cleanup_dokken_sandbox
       end
 


### PR DESCRIPTION
Hi, 👋 
I have a few cookbooks that download substantial amounts of remote files and having the `kitchen_sandbox` get cleaned after every `kitchen converge`. This massively increases converge time where we didn't have that issue on `kitchen-vagrant`. 

The PR adds an option to opt out of cleaning the kitchen sandbox. It defaults to do the cleaning, i.e. no changing existing behaviour. 

Thanks for reviewing,

Chris