### PR TITLE
Fixes #167 Allow configurable container memory limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,16 @@ platforms:
       chef_binary: /bin/true
 ```
 
+### Controlling container memory
+
+By default the memory limit of the containers you run is unbound (or limited by the Docker client on OSX). If however you need to constrain the container memory allocation you can set a memory limit in bytes on the driver:
+
+```yaml
+driver:
+  name: dokken
+  memory_limit: 2147483648 # 2GB
+```
+
 ## FAQ
 
 ### What about kitchen-docker?

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -61,6 +61,7 @@ module Kitchen
       default_config :userns_host, false
       default_config :pull_platform_image, true
       default_config :pull_chef_image, true
+      default_config :memory_limit, 0
 
       # (see Base#create)
       def create(state)
@@ -300,6 +301,7 @@ module Kitchen
             'NetworkMode' => self[:network_mode],
             'PortBindings' => port_bindings,
             'Tmpfs' => dokken_tmpfs,
+            'Memory' => self[:memory_limit],
           },
           'NetworkingConfig' => {
             'EndpointsConfig' => {


### PR DESCRIPTION
Allows setting a memory limit in bytes in the driver block