### PR TITLE
Fix multiple_converge

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,7 @@ driver:
   chef_version: latest
   privileged: true
   volumes: [ '/var/lib/docker' ]
+  env: [CHEF_LICENSE=accept]
 
 transport:
   name: dokken
@@ -25,9 +26,9 @@ platforms:
     provisioner:
       chef_binary: /bin/true
 
-  - name: fedora
+  - name: centos
     driver:
-      image: fedora:latest
+      image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
       volumes:
         - <%= ENV['PWD'] %>/.git:/opt/kitchen-dokken/.git
@@ -40,12 +41,22 @@ platforms:
 suites:
   - name: default
     includes:
-      - fedora
+      - centos
     run_list:
       - recipe[dokken_test::default]
     attributes:
       dokken_test:
         revision: <%= `git rev-parse HEAD` %>
+
+  - name: idempotency
+    includes:
+      - centos
+    provisioner:
+      enforce_idempotency: true
+      multiple_converge: 2
+      deprecations_as_errors: true
+    run_list:
+      - recipe[dokken_test::idempotency]
 
   - name: hello
     driver:

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ gem 'test-kitchen'
 
 group :development do
   gem 'pry'
-  gem 'pry-coolline'
+  gem 'pry-byebug'
 end

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -55,6 +55,7 @@ module Kitchen
       # (see Base#call)
       def call(state)
         create_sandbox
+        write_run_command(run_command)
         instance.transport.connection(state) do |conn|
           if remote_docker_host?
             info("Transferring files to #{instance.to_str}")
@@ -63,7 +64,7 @@ module Kitchen
 
           conn.execute(prepare_command)
           conn.execute_with_retry(
-            run_command,
+            "sh #{config[:root_path]}/run_command",
             config[:retry_on_exit_code],
             config[:max_retries],
             config[:wait_for_retry]
@@ -105,6 +106,12 @@ module Kitchen
         cmd << " -F #{config[:chef_output_format]}"
         cmd << ' -c /opt/kitchen/client.rb'
         cmd << ' -j /opt/kitchen/dna.json'
+
+        chef_cmd(cmd)
+      end
+
+      def write_run_command(command)
+        File.write("#{dokken_kitchen_sandbox}/run_command", command)
       end
 
       def runner_container_name


### PR DESCRIPTION
This fixes #194 and allows one to finally use enforce_idempotency and
multiple_converge with dokken. This is done by calling ``chef_cmd`` which
properly generates the code needed for adding enforce_idempotency and
multiple_converge.

To workaround an issue with ShellWords filtering out single quotes from
``chef_cmd``, the ``run_command`` gets written out as a file in the kitchen
sandbox and then executed directly.

Some other mix changes:
- Fix .kitchen.yml used for testing and switch to using CentOS 7 as the latest
  Fedora was having issues and this should be more stable
- Fix .kitchen.yml so that Chef 15 and newer accept the license properly
- Replace pry-coolline with pry-byebug so that pry debugging works properly

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved
- Fixes #194 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
