### PR TITLE
Fix kitchen instance and make Travis lint happy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 rvm:
   - 2.5.1
 cache: bundler
-sudo: required
 group: edge
+dist: xenial
+os: linux
+language: ruby
 
 services: docker
 
@@ -16,7 +18,7 @@ branches:
 env:
   global:
     - KITCHEN_YAML=.kitchen.yml
-    - INSTANCE=default-fedora
+    - INSTANCE=default-centos
     - CHEF_LICENSE="accept-no-persist"
 
 before_install:


### PR DESCRIPTION
The change merged in #195 changed the `fedora` platform to `centos`, so we need to change `.travis.yml`. Also, Travis now lints your configuration, and it points out that `sudo:` is superfluous and that it's using default values for `dist`, `os`, and `language`.

# Description

Fixes up problems I see in Travis when testing a fork

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
