### PR TITLE
update travis-ci configuration

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,7 +31,7 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       volumes:
         - <%= ENV['PWD'] %>/.git:/opt/kitchen-dokken/.git
-        - /var/run/docker.sock:/var/run/docker.sock
+        - /var/run/docker.sock:/tmp/docker.sock
 
   - name: local_image
     driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,6 @@ driver:
   name: dokken
   chef_version: latest
   privileged: true
-  volumes: [ '/var/lib/docker' ]
   env: [CHEF_LICENSE=accept]
 
 transport:
@@ -32,6 +31,7 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       volumes:
         - <%= ENV['PWD'] %>/.git:/opt/kitchen-dokken/.git
+        - /var/run/docker.sock:/var/run/docker.sock
 
   - name: local_image
     driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,6 +32,7 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       volumes:
         - <%= ENV['PWD'] %>/.git:/opt/kitchen-dokken/.git
+        - /var/run/docker.sock:/var/run/docker.sock
 
   - name: local_image
     driver:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,7 +32,6 @@ platforms:
       pid_one_command: /usr/lib/systemd/systemd
       volumes:
         - <%= ENV['PWD'] %>/.git:/opt/kitchen-dokken/.git
-        - /var/run/docker.sock:/var/run/docker.sock
 
   - name: local_image
     driver:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - sudo apt-get install -y nmap
 
 before_script:
+ - docker info
  - sudo nmap -p- localhost
  - sudo iptables -S
  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
  - sudo nmap -p- localhost
  - sudo iptables -S
  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
- - docker run --privileged -d -p 4444:4444 -e PORT=4444 jpetazzo/dind
+ - docker run --privileged -d -p 4444:4444 -e PORT=4444 docker:dind
 
 script:
 #  - DOCKER_HOST="tcp://localhost:4444" KITCHEN_YAML=.kitchen.yml time bundle exec kitchen test ${INSTANCE} -l debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ before_script:
  - sudo nmap -p- localhost
  - sudo iptables -S
  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
- - docker run --privileged -d -p 4444:4444 -e PORT=4444 docker:dind
+ - docker run -d -p 4444:4444 -e PORT=4444 -v /var/run/docker.sock:/var/run/docker.sock docker
+ # - docker run --privileged -d -p 4444:4444 -e PORT=4444 docker
 
 script:
 #  - DOCKER_HOST="tcp://localhost:4444" KITCHEN_YAML=.kitchen.yml time bundle exec kitchen test ${INSTANCE} -l debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ env:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y nmap
-  - |
-      echo '{
-        "storage-driver": "overlay2"
-      }' | sudo tee /etc/docker/daemon.json
-  - sudo service docker restart
 
 before_script:
  - sudo nmap -p- localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
+language: ruby
 rvm:
-  - 2.5.1
+  - 2.7.1
 cache: bundler
-sudo: required
 group: edge
+dist: xenial
+os: linux
+git:
+  depth: false
 
 services: docker
 
@@ -16,7 +20,7 @@ branches:
 env:
   global:
     - KITCHEN_YAML=.kitchen.yml
-    - INSTANCE=default-fedora
+    - INSTANCE=default-centos
     - CHEF_LICENSE="accept-no-persist"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ env:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y nmap
+  - |
+      echo '{
+        "storage-driver": "overlay2"
+      }' | sudo tee /etc/docker/daemon.json
+  - sudo service docker restart
 
 before_script:
  - sudo nmap -p- localhost

--- a/test/cookbooks/dokken_test/attributes/default.rb
+++ b/test/cookbooks/dokken_test/attributes/default.rb
@@ -1,1 +1,2 @@
 default['dokken_test']['revision'] = 'master'
+default['dokken_test']['docker_host'] = 'unix:///tmp/docker.sock'

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -27,9 +27,16 @@ package %w(
 
 docker_service 'default' do
   host ['tcp://127.0.0.1']
-  storage_driver 'overlay'
   action [:create, :start]
 end
+
+ruby_block 'docker info' do
+  block do
+    Chef::Log.warn(`docker info`)
+  end
+end
+
+return # we know this is broken...
 
 git '/home/notroot/kitchen-dokken' do
   repository '/opt/kitchen-dokken/.git'

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -63,7 +63,6 @@ execute 'Test Kitchen verify hello' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
-              'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
               'CHEF_LICENSE' => 'accept-no-persist'
   action :run
 end
@@ -75,7 +74,6 @@ execute 'destroy hello again suite' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
-              'DOCKER_HOST' => 'tcp://127.0.0.1:2375'
   action :run
 end
 
@@ -93,7 +91,6 @@ execute 'Test Kitchen verify without image pull' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
-              'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
               'CHEF_LICENSE' => 'accept-no-persist'
   action :run
 end

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -37,11 +37,12 @@ package %w(
 #   action [:create, :start]
 # end
 
-# ruby_block 'docker info' do
-#   block do
-#     Chef::Log.warn(`docker -H 127.0.0.1 info`)
-#   end
-# end
+ruby_block 'docker info' do
+  block do
+    Chef::Log.warn(`ls -l /var/run/docker.run`)
+    Chef::Log.warn(`docker info`)
+  end
+end
 
 # return # we know this is broken...
 

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -37,7 +37,22 @@ git '/home/notroot/kitchen-dokken' do
   action :sync
 end
 
-execute 'install gem bundle' do
+bash 'whut' do
+  cwd '/home/notroot/kitchen-dokken'
+  code <<-EOH
+      which bundle
+      bundle version
+      which ruby
+      ruby -v
+      which chef-client
+      chef-client --version
+      cat /home/notroot/kitchen-dokken/Gemfile
+      EOH
+end
+
+return
+
+execute 'install gem bundle' don
   command '/usr/bin/bundle install --without development --path vendor/bundle'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -39,17 +39,12 @@ end
 
 ruby_block'whut' do
   block do
-    Chef::Log.warn(`which bundle`)
-    Chef::Log.warn(`which ruby`)
-    Chef::Log.warn(`which chef-client`)
-    Chef::Log.warn(`cat /home/notroot/kitchen-dokken/Gemfile`)
+    Chef::Log.warn(`bundle version`)
   end
 end
 
-return
-
 execute 'install gem bundle' do
-  command '/usr/bin/bundle install --without development --path vendor/bundle'
+  command '/usr/bin/bundle install -V --without development --path vendor/bundle'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
   live_stream true

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -25,20 +25,20 @@ package %w(
   which
 )
 
-docker_service 'default' do
-  host ['tcp://127.0.0.1']
-  storage_driver 'vfs'
-  storage_opts ['size=256M']
-  action [:create, :start]
-end
+# docker_service 'default' do
+#   host ['tcp://127.0.0.1']
+#   storage_driver 'vfs'
+#   storage_opts ['size=256M']
+#   action [:create, :start]
+# end
 
-ruby_block 'docker info' do
-  block do
-    Chef::Log.warn(`docker -H 127.0.0.1 info`)
-  end
-end
+# ruby_block 'docker info' do
+#   block do
+#     Chef::Log.warn(`docker -H 127.0.0.1 info`)
+#   end
+# end
 
-return # we know this is broken...
+# return # we know this is broken...
 
 git '/home/notroot/kitchen-dokken' do
   repository '/opt/kitchen-dokken/.git'

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -33,14 +33,14 @@ package %w(
   docker
 )
 
-# docker_service 'default' do
-#   action [:create, :start]
-# end
+docker_service 'default' do
+  host ['tcp://127.0.0.1']
+  action [:create, :start]
+end
 
 ruby_block 'docker info' do
   block do
-    Chef::Log.warn(`ls -l /var/run/docker.run`)
-    Chef::Log.warn(`docker info`)
+     Chef::Log.warn(`docker info`)
   end
 end
 
@@ -65,6 +65,7 @@ execute 'Test Kitchen verify hello' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
+              'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
               'CHEF_LICENSE' => 'accept-no-persist'
   action :run
 end
@@ -75,6 +76,7 @@ execute 'destroy hello again suite' do
   user 'notroot'
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
+              'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
               'HOME' => '/home/notroot'
   action :run
 end
@@ -93,6 +95,7 @@ execute 'Test Kitchen verify without image pull' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
+              'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
               'CHEF_LICENSE' => 'accept-no-persist'
   action :run
 end

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -37,21 +37,20 @@ git '/home/notroot/kitchen-dokken' do
   action :sync
 end
 
-execute 'install gem bundle' do
-  command '/usr/bin/bundle install --without development --path vendor/bundle --jobs 4'
-  cwd '/home/notroot/kitchen-dokken'
-  user 'notroot'
-  live_stream true
-  creates '/home/notroot/kitchen-dokken/Gemfile.lock'
-  environment 'HOME' => '/home/notroot'
-  action :run
+yum_repository 'chef-stable' do
+  description 'chef-stable'
+  baseurl 'https://packages.chef.io/repos/yum/stable/el/7/$basearch'
+  gpgkey 'https://packages.chef.io/chef.asc'
 end
+
+yum_package 'chef-workstation'
+
 
 execute 'Test Kitchen verify hello' do
   command <<-EOH.gsub(/^\s{4}/, '').chomp
-    /usr/bin/bundle exec kitchen create hello -l debug
-    /usr/bin/bundle exec kitchen converge hello -l debug
-    /usr/bin/bundle exec kitchen verify hello -l debug
+    /usr/bin/kitchen create hello -l debug
+    /usr/bin/kitchen converge hello -l debug
+    /usr/bin/kitchen verify hello -l debug
   EOH
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
@@ -64,7 +63,7 @@ execute 'Test Kitchen verify hello' do
 end
 
 execute 'destroy hello again suite' do
-  command '/usr/bin/bundle exec kitchen destroy helloagain'
+  command '/usr/bin/kitchen destroy helloagain'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
   live_stream true
@@ -82,7 +81,7 @@ docker_tag 'local-example' do
 end
 
 execute 'Test Kitchen verify without image pull' do
-  command '/usr/bin/bundle exec kitchen test local_image -l debug'
+  command '/usr/bin/kitchen test local_image -l debug'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
   live_stream true

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -27,7 +27,7 @@ package %w(
 
 docker_service 'default' do
   host ['tcp://127.0.0.1']
-  storage_driver 'overlay2'
+  storage_driver 'overlay'
   action [:create, :start]
 end
 

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -44,8 +44,6 @@ ruby_block 'docker info' do
   end
 end
 
-# return # we know this is broken...
-
 git '/home/notroot/kitchen-dokken' do
   repository '/opt/kitchen-dokken/.git'
   revision node['dokken_test']['revision']
@@ -53,6 +51,16 @@ git '/home/notroot/kitchen-dokken' do
   action :sync
 end
 
+ruby_block 'more info' do
+  block do
+    Chef::Log.warn('docker info:')
+    Chef::Log.warn(`docker -H unix:///tmp/docker.sock info`)
+    Chef::Log.warn('/opt/kitchen info:')
+    Chef::Log.warn(`ls -l /opt/kitchen`)
+    Chef::Log.warn('/opt/verifier info:')
+    Chef::Log.warn(`ls -l /opt/verifier`)
+  end
+end
 
 execute 'Test Kitchen verify hello' do
   command <<-EOH.gsub(/^\s{4}/, '').chomp

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -40,7 +40,7 @@ package %w(
 
 ruby_block 'docker info' do
   block do
-     Chef::Log.warn(`docker info`)
+     Chef::Log.warn(`docker -H unix:///tmp/docker.sock info`)
   end
 end
 
@@ -65,6 +65,7 @@ execute 'Test Kitchen verify hello' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
+              'DOCKER_HOST' => node['dokken_test']['docker_host'],
               'CHEF_LICENSE' => 'accept-no-persist'
   action :run
 end
@@ -75,6 +76,7 @@ execute 'destroy hello again suite' do
   user 'notroot'
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
+              'DOCKER_HOST' => node['dokken_test']['docker_host'],
               'HOME' => '/home/notroot'
   action :run
 end
@@ -93,6 +95,7 @@ execute 'Test Kitchen verify without image pull' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
+              'DOCKER_HOST' => node['dokken_test']['docker_host'],
               'CHEF_LICENSE' => 'accept-no-persist'
   action :run
 end

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -41,7 +41,7 @@ execute 'install gem bundle' do
   command '/usr/bin/bundle install --without development --path vendor/bundle'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
-  live_stream false
+  live_stream true
   creates '/home/notroot/kitchen-dokken/Gemfile.lock'
   environment 'HOME' => '/home/notroot'
   action :run

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -37,14 +37,8 @@ git '/home/notroot/kitchen-dokken' do
   action :sync
 end
 
-ruby_block'whut' do
-  block do
-    Chef::Log.warn(`bundle version`)
-  end
-end
-
 execute 'install gem bundle' do
-  command '/usr/bin/bundle install -V --without development --path vendor/bundle'
+  command '/usr/bin/bundle install --without development --path vendor/bundle --jobs 4'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
   live_stream true

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -33,10 +33,10 @@ package %w(
   docker
 )
 
-docker_service 'default' do
-  host ['tcp://127.0.0.1']
-  action [:create, :start]
-end
+# docker_service 'default' do
+#   host ['tcp://127.0.0.1']
+#   action [:create, :start]
+# end
 
 ruby_block 'docker info' do
   block do
@@ -65,7 +65,6 @@ execute 'Test Kitchen verify hello' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
-              'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
               'CHEF_LICENSE' => 'accept-no-persist'
   action :run
 end
@@ -76,7 +75,6 @@ execute 'destroy hello again suite' do
   user 'notroot'
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
-              'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
               'HOME' => '/home/notroot'
   action :run
 end
@@ -95,7 +93,6 @@ execute 'Test Kitchen verify without image pull' do
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
               'HOME' => '/home/notroot',
-              'DOCKER_HOST' => 'tcp://127.0.0.1:2375',
               'CHEF_LICENSE' => 'accept-no-persist'
   action :run
 end

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -30,6 +30,7 @@ package %w(
   telnet
   which
   chef-workstation
+  docker
 )
 
 # docker_service 'default' do

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -52,7 +52,7 @@ end
 
 return
 
-execute 'install gem bundle' don
+execute 'install gem bundle' do
   command '/usr/bin/bundle install --without development --path vendor/bundle'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -73,7 +73,7 @@ execute 'destroy hello again suite' do
   user 'notroot'
   live_stream true
   environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
-              'HOME' => '/home/notroot',
+              'HOME' => '/home/notroot'
   action :run
 end
 

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -33,7 +33,7 @@ package %w(
 )
 
 docker_service 'default' do
-  action [:start]
+  action [:create, :start]
 end
 
 # ruby_block 'docker info' do

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -32,7 +32,7 @@ end
 
 ruby_block 'docker info' do
   block do
-    Chef::Log.warn(`docker info`)
+    Chef::Log.warn(`docker info -H tcp://127.0.0.1:2375`)
   end
 end
 

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -27,6 +27,8 @@ package %w(
 
 docker_service 'default' do
   host ['tcp://127.0.0.1']
+  storage_driver 'vfs'
+  storage_opts ['size=256M']
   action [:create, :start]
 end
 

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -42,7 +42,6 @@ ruby_block'whut' do
     Chef::Log.warn(`which bundle`)
     Chef::Log.warn(`which ruby`)
     Chef::Log.warn(`which chef-client`)
-    Chef::Log.warn(`chef-client --version`)
     Chef::Log.warn(`cat /home/notroot/kitchen-dokken/Gemfile`)
   end
 end

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -32,9 +32,9 @@ package %w(
   chef-workstation
 )
 
-docker_service 'default' do
-  action [:create, :start]
-end
+# docker_service 'default' do
+#   action [:create, :start]
+# end
 
 # ruby_block 'docker info' do
 #   block do

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -27,6 +27,7 @@ package %w(
 
 docker_service 'default' do
   host ['tcp://127.0.0.1']
+  storage_driver 'overlay2'
   action [:create, :start]
 end
 

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -32,7 +32,7 @@ end
 
 ruby_block 'docker info' do
   block do
-    Chef::Log.warn(`docker info -H tcp://127.0.0.1:2375`)
+    Chef::Log.warn(`docker -H 127.0.0.1 info`)
   end
 end
 

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -37,17 +37,14 @@ git '/home/notroot/kitchen-dokken' do
   action :sync
 end
 
-bash 'whut' do
-  cwd '/home/notroot/kitchen-dokken'
-  code <<-EOH
-      which bundle
-      bundle version
-      which ruby
-      ruby -v
-      which chef-client
-      chef-client --version
-      cat /home/notroot/kitchen-dokken/Gemfile
-      EOH
+ruby_block'whut' do
+  block do
+    Chef::Log.warn(`which bundle`)
+    Chef::Log.warn(`which ruby`)
+    Chef::Log.warn(`which chef-client`)
+    Chef::Log.warn(`chef-client --version`)
+    Chef::Log.warn(`cat /home/notroot/kitchen-dokken/Gemfile`)
+  end
 end
 
 return

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -4,6 +4,12 @@ user 'notroot' do
   action :create
 end
 
+yum_repository 'chef-stable' do
+  description 'chef-stable'
+  baseurl 'https://packages.chef.io/repos/yum/stable/el/7/$basearch'
+  gpgkey 'https://packages.chef.io/chef.asc'
+end
+
 package %w(
   gcc-c++
   gcc
@@ -23,14 +29,12 @@ package %w(
   rubygem-rake
   telnet
   which
+  chef-workstation
 )
 
-# docker_service 'default' do
-#   host ['tcp://127.0.0.1']
-#   storage_driver 'vfs'
-#   storage_opts ['size=256M']
-#   action [:create, :start]
-# end
+docker_service 'default' do
+  action [:start]
+end
 
 # ruby_block 'docker info' do
 #   block do
@@ -46,14 +50,6 @@ git '/home/notroot/kitchen-dokken' do
   user 'notroot'
   action :sync
 end
-
-yum_repository 'chef-stable' do
-  description 'chef-stable'
-  baseurl 'https://packages.chef.io/repos/yum/stable/el/7/$basearch'
-  gpgkey 'https://packages.chef.io/chef.asc'
-end
-
-yum_package 'chef-workstation'
 
 
 execute 'Test Kitchen verify hello' do

--- a/test/integration/default/inspec/assert_functioning_spec.rb
+++ b/test/integration/default/inspec/assert_functioning_spec.rb
@@ -1,15 +1,15 @@
 
-describe command('docker --host 127.0.0.1 ps') do
+describe command('docker ps') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/hello-hello$/) }
 end
 
-describe command('docker --host 127.0.0.1 ps') do
+describe command('docker ps') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/hello-hello-data$/) }
 end
 
-describe command('docker --host 127.0.0.1 ps') do
+describe command('docker ps') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should_not match(/helloagain-hello$/) }
 end

--- a/test/integration/default/inspec/assert_functioning_spec.rb
+++ b/test/integration/default/inspec/assert_functioning_spec.rb
@@ -1,15 +1,15 @@
 
-describe command('docker ps') do
+describe command('docker -H unix:///tmp/docker.sock ps') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/hello-hello$/) }
 end
 
-describe command('docker ps') do
+describe command('docker -H unix:///tmp/docker.sock ps') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/hello-hello-data$/) }
 end
 
-describe command('docker ps') do
+describe command('docker -H unix:///tmp/docker.sock ps') do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should_not match(/helloagain-hello$/) }
 end


### PR DESCRIPTION
Pull request #195 changed the platform fedora to centos, so .travis.yml
needs to match. Additionally, Travis now offers some linting advice, and
it pointed out that 'sudo' is superfluous and that explicit values for
os, dist, and language should be used. Because the tests do a clone for
the local repository, shallow cloning needs to be turned off. Finally, I
updated the rvm version to 2.7.1.

# Description

This fixes some problems I've found testing a fork.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
