### PR TITLE
Optimize our requires and use .match? not .match

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -15,9 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'digest'
+require 'digest' unless defined?(Digest)
 require 'kitchen'
-require 'tmpdir'
+require 'tmpdir' unless defined?(Dir.mktmpdir)
 require 'docker'
 require 'lockfile'
 require_relative '../helpers'

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -1,8 +1,8 @@
 module Dokken
   module Helpers
     # https://stackoverflow.com/questions/517219/ruby-see-if-a-port-is-open
-    require 'socket'
-    require 'timeout'
+    require 'socket' unless defined?(Socket)
+    require 'timeout' unless defined?(Timeout)
 
     def port_open?(ip, port)
       begin
@@ -243,7 +243,7 @@ VOLUME /opt/verifier
 
     def remote_docker_host?
       return false if config[:docker_info]['OperatingSystem'].include?('Boot2Docker')
-      return true if config[:docker_host_url] =~ /^tcp:/
+      return true if /^tcp:/.match?(config[:docker_host_url])
       false
     end
 


### PR DESCRIPTION
Rubygems is very slow to traverse the filesystem when a dep is in fact
already loaded. Let's avoid that by gating many of the requires. This
also converts to .match? which avoids creating the whole match object.

Signed-off-by: Tim Smith <tsmith@chef.io>