### PR TITLE
Allow docker-api 2.0 which removes the API version constraint

### DIFF
--- a/kitchen-dokken.gemspec
+++ b/kitchen-dokken.gemspec
@@ -7,15 +7,15 @@ Gem::Specification.new do |spec|
   spec.version       = Kitchen::Driver::DOKKEN_VERSION
   spec.authors       = ['Sean OMeara']
   spec.email         = ['sean@sean.io']
-  spec.description   = 'A Test Kitchen Driver for Dokken'
-  spec.summary       = 'A Test Kitchen Driver that talks to the Docker Remote API and uses Volumes to produce sparse container images'
+  spec.description   = 'A Test Kitchen Driver for Docker & Chef Infra optimized for rapid testing using Chef Infra docker images'
+  spec.summary       = 'A Test Kitchen Driver for Docker & Chef Infra optimized for rapid testing using Chef Infra docker images'
   spec.homepage      = 'https://github.com/someara/kitchen-dokken'
   spec.license       = 'Apache-2.0'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^lib/)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'docker-api', '~> 1.33'
+  spec.add_dependency 'docker-api', '>= 1.33', '< 3'
   spec.add_dependency 'lockfile', '~> 2.1'
   spec.add_dependency 'test-kitchen', '>= 1.15', '< 3'
 end


### PR DESCRIPTION
Also improve the description to make it clear this only works with Chef

Signed-off-by: Tim Smith <tsmith@chef.io>