### PR TITLE
Handle unreachable network errors

### DIFF
--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -11,7 +11,7 @@ module Dokken
             s = TCPSocket.new(ip, port)
             s.close
             return true
-          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Errno::ENETDOWN
             return false
           end
         end


### PR DESCRIPTION
Consider the port as closed when the target network is either
unreachable or down as well. This can happen depending on the kitchen
hosts routing and the network it's connected to