### PR TITLE
Fix typo in error message.

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -153,9 +153,9 @@ module Kitchen
         rescue Docker::Error::UnexpectedResponseError => e
           msg = 'work_image build failed: '
           msg += JSON.parse(e.to_s.split("\r\n").last)['error'].to_s
-          msg += '. The common scenerios are incorrect intermediate'
+          msg += '. The common scenarios are incorrect intermediate'
           msg += 'instructions such as not including `-y` on an `apt-get` '
-          msg += 'or similar. The other common scenerio is a transient '
+          msg += 'or similar. The other common scenario is a transient '
           msg += 'error such as an unresponsive mirror.'
           raise msg
         # fallback rescue above should catch most of the errors


### PR DESCRIPTION
# Description

Fix a typo noticed in a CI failure on chef/chef.

## Issues Resolved

> Failed to complete #create action: [work_image build failed: The command '/bin/sh -c yum install -y centos-release-scl' returned a non-zero code: 1. The common scenerios are incorrect intermediateinstructions such as not including `-y` on an `apt-get` or similar. The other common scenerio is a transient error such as an unresponsive mirror.] on end-to-end-centos-6

https://buildkite.com/chef-oss/chef-chef-master-verify/builds/7181#563d5663-bd03-4958-9cc8-b15272d9b2e0/778-794

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
