### PR TITLE
Fix bad concatenation in error message

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -153,7 +153,7 @@ module Kitchen
         rescue Docker::Error::UnexpectedResponseError => e
           msg = 'work_image build failed: '
           msg += JSON.parse(e.to_s.split("\r\n").last)['error'].to_s
-          msg += '. The common scenarios are incorrect intermediate'
+          msg += '. The common scenarios are incorrect intermediate '
           msg += 'instructions such as not including `-y` on an `apt-get` '
           msg += 'or similar. The other common scenario is a transient '
           msg += 'error such as an unresponsive mirror.'


### PR DESCRIPTION
# Description

Missed in #209. This error message reads awkwardly.

## Issues Resolved

This error message incorrectly concatenates two lines without a space, resulting in `intermediateinstructions`.

> Failed to complete #create action: [work_image build failed: The command '/bin/sh -c yum install -y centos-release-scl' returned a non-zero code: 1. The common scenerios are incorrect intermediateinstructions such as not including `-y` on an `apt-get` or similar. The other common scenerio is a transient error such as an unresponsive mirror.] on end-to-end-centos-6

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
