### PR TITLE
Add an hostname_aliases parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,17 @@ driver:
   memory_limit: 2147483648 # 2GB
 ```
 
+### Adding hostname aliases
+
+You can set the `aliases` parameter to create additional hostnames that will resolve to the container:
+
+```yaml
+driver:
+  name: dokken
+  aliases:
+    - foo
+```
+
 ## FAQ
 
 ### What about kitchen-docker?

--- a/README.md
+++ b/README.md
@@ -560,12 +560,12 @@ driver:
 
 ### Adding hostname aliases
 
-You can set the `aliases` parameter to create additional hostnames that will resolve to the container:
+You can set the `hostname_aliases` parameter to create additional hostnames that will resolve to the container:
 
 ```yaml
 driver:
   name: dokken
-  aliases:
+  hostname_aliases:
     - foo
 ```
 

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -33,7 +33,6 @@ module Kitchen
     #
     # @author Sean OMeara <sean@sean.io>
     class Dokken < Kitchen::Driver::Base
-      default_config :aliases, nil
       default_config :api_retries, 20
       default_config :binds, []
       default_config :cap_add, nil
@@ -49,6 +48,7 @@ module Kitchen
       default_config :ports, nil
       default_config :docker_host_url, default_docker_host
       default_config :hostname, "dokken"
+      default_config :hostname_aliases, nil
       default_config :image_prefix, nil
       default_config :links, nil
       default_config :network_mode, "dokken"
@@ -310,7 +310,7 @@ module Kitchen
           "NetworkingConfig" => {
             "EndpointsConfig" => {
               self[:network_mode] => {
-                "Aliases" => Array(self[:hostname]).concat(Array(self[:aliases])),
+                "Aliases" => Array(self[:hostname]).concat(Array(self[:hostname_aliases])),
               },
             },
           },

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -33,6 +33,7 @@ module Kitchen
     #
     # @author Sean OMeara <sean@sean.io>
     class Dokken < Kitchen::Driver::Base
+      default_config :aliases, nil
       default_config :api_retries, 20
       default_config :binds, []
       default_config :cap_add, nil
@@ -309,7 +310,7 @@ module Kitchen
           "NetworkingConfig" => {
             "EndpointsConfig" => {
               self[:network_mode] => {
-                "Aliases" => Array(self[:hostname]),
+                "Aliases" => Array(self[:hostname]).concat(Array(self[:aliases])),
               },
             },
           },


### PR DESCRIPTION
# Description

Adds an "aliases" parameter to the dokken driver that sets the same parameter in the Docker create request. This enables testing of cookbooks that depend on resolving multiple hostnames, such as cookbooks that configure multiple Apache virtual hosts.

## Issues Resolved

None.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
