### PR TITLE
Fix `docker_registry` plus some cleanups

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -169,8 +169,10 @@ module Kitchen
       end
 
       def work_image_dockerfile
+        from = registry_image_path(platform_image)
+        debug("driver - Building work image from #{from}")
         dockerfile_contents = [
-          "FROM #{platform_image}",
+          "FROM #{from}",
           "LABEL X-Built-By=kitchen-dokken X-Built-From=#{platform_image}",
         ]
         Array(config[:intermediate_instructions]).each do |c|
@@ -287,7 +289,8 @@ module Kitchen
         config = {
           "name" => runner_container_name,
           "Cmd" => Shellwords.shellwords(self[:pid_one_command]),
-          "Image" => "#{repo(work_image)}:#{tag(work_image)}",
+          # locally built image, must use short-name
+          "Image" => short_image_path(work_image),
           "Hostname" => self[:hostname],
           "Env" => self[:env],
           "ExposedPorts" => exposed_ports,
@@ -329,7 +332,8 @@ module Kitchen
         debug "driver - creating #{data_container_name}"
         config = {
           "name" => data_container_name,
-          "Image" => "#{repo(data_image)}:#{tag(data_image)}",
+          # locally built image, must use short-name
+          "Image" => short_image_path(data_image),
           "HostConfig" => {
             "PortBindings" => port_bindings,
             "PublishAllPorts" => true,
@@ -352,7 +356,7 @@ module Kitchen
         begin
           lockfile.lock
           with_retries { ::Docker::Network.get("dokken", {}, docker_connection) }
-        rescue
+        rescue ::Docker::Error::NotFoundError
           begin
             with_retries { ::Docker::Network.create("dokken", {}) }
           rescue ::Docker::Error => e
@@ -388,14 +392,14 @@ module Kitchen
             config = {
               "name" => chef_container_name,
               "Cmd" => "true",
-              "Image" => "#{repo(chef_image)}:#{tag(chef_image)}",
+              "Image" => registry_image_path(chef_image),
               "HostConfig" => {
                 "NetworkMode" => self[:network_mode],
               },
             }
             chef_container = create_container(config)
             state[:chef_container] = chef_container.json
-          rescue ::Docker::Error => e
+          rescue ::Docker::Error, StandardError => e
             raise "driver - #{chef_container_name} failed to create #{e}"
           end
         ensure
@@ -404,12 +408,12 @@ module Kitchen
       end
 
       def pull_platform_image
-        debug "driver - pulling #{chef_image} #{repo(platform_image)} #{tag(platform_image)}"
+        debug "driver - pulling #{short_image_path(platform_image)}"
         config[:pull_platform_image] ? pull_image(platform_image) : pull_if_missing(platform_image)
       end
 
       def pull_chef_image
-        debug "driver - pulling #{chef_image} #{repo(chef_image)} #{tag(chef_image)}"
+        debug "driver - pulling #{short_image_path(chef_image)}"
         config[:pull_chef_image] ? pull_image(chef_image) : pull_if_missing(chef_image)
       end
 
@@ -422,7 +426,7 @@ module Kitchen
 
       def container_exist?(name)
         return true if ::Docker::Container.get(name, {}, docker_connection)
-      rescue
+      rescue StandardError, ::Docker::Error::NotFoundError
         false
       end
 
@@ -440,8 +444,43 @@ module Kitchen
         [repo, tag]
       end
 
+      # Return the 'repo' half of a docker image path. Agnostic about if a
+      # registry is included, this effectively is just "before the colon"
+      #
+      # @param image [String] the docker image path to parse
+      # @return [String] the repo portion of `image`
       def repo(image)
         parse_image_name(image)[0]
+      end
+
+      # Return the 'tag' of a docker image path. Will be `latest` if there
+      # is no explicit tag in the image path.
+      #
+      # @param image [String] the docker image path to parse
+      # @return [String] the tag of `image`
+      def tag(image)
+        parse_image_name(image)[1]
+      end
+
+      # Ensures an explicit tag on an image path.
+      #
+      # @param image [String] the docker image path to parse
+      # @return [String] `repo`:`tag`
+      def short_image_path(image)
+        "#{repo(image)}:#{tag(image)}"
+      end
+
+      # Qualifies the results of `short_image_path` with any registry the
+      # user has requested
+      #
+      # @param image [String] the docker image path to parse
+      # @return [String] The most fully-qualified registry path we cn make
+      def registry_image_path(image)
+        if config[:docker_registry]
+          "#{config[:docker_registry]}/#{short_image_path(image)}"
+        else
+          short_image_path(image)
+        end
       end
 
       def create_container(args)
@@ -511,10 +550,6 @@ module Kitchen
         end
       end
 
-      def tag(image)
-        parse_image_name(image)[1]
-      end
-
       def chef_container_name
         "chef-#{chef_version}"
       end
@@ -547,7 +582,7 @@ module Kitchen
       end
 
       def pull_if_missing(image)
-        return if ::Docker::Image.exist?("#{repo(image)}:#{tag(image)}", {}, docker_connection)
+        return if ::Docker::Image.exist?(registry_image_path(image), {}, docker_connection)
 
         pull_image image
       end
@@ -557,21 +592,14 @@ module Kitchen
         val.sub(%r{https?://}, "").split("/").first
       end
 
-      def image_path(image)
-        fqimage = "#{repo(image)}:#{tag(image)}"
-        if config[:docker_registry]
-          fqimage = "#{config[:docker_registry]}/#{fqimage}"
-        end
-        fqimage
-      end
-
       def pull_image(image)
+        path = registry_image_path(image)
         with_retries do
-          if Docker::Image.exist?(image_path(image), {}, docker_connection)
-            original_image = Docker::Image.get(image_path(image), {}, docker_connection)
+          if Docker::Image.exist?(path, {}, docker_connection)
+            original_image = Docker::Image.get(path, {}, docker_connection)
           end
 
-          new_image = Docker::Image.create({ "fromImage" => "#{repo(image)}:#{tag(image)}" }, docker_connection)
+          new_image = Docker::Image.create({ "fromImage" => path }, docker_connection)
 
           !(original_image && original_image.id.start_with?(new_image.id))
         end


### PR DESCRIPTION
This PR extends the feature added in #218. Unfortunately there's a million
little places where docker decides to reach out to docker.io and if you
already have that image, or if you're not over you quota, it's hard to catch
it. This time I've done a lot of work to make sure every case is caught.

Further, the 'data image' doesn't get built unless you have a remote docker
host which I didn't in my testing, so that never got properly tested and was
broken when used with `docker_registry`, but it now works.

In addition I abstracted out a bit of the repetative code used to assemble
image names as well fixed some blatantly false debug messages, and added some
additional exceptions we weren't catching, plus filled in places we were
catching anything blindly.

The code is easier to read now, and I'm quite confident it's working as
advertised as I'm using it to run tests.