### PR TITLE
Fixes for Windows Execution

### DIFF
--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -117,6 +117,8 @@ VOLUME /opt/verifier
     end
 
     def docker_info
+      ::Docker.url = default_docker_host
+
       @docker_info ||= ::Docker.info
     rescue Excon::Error::Socket
       puts "kitchen-dokken could not connect to the docker host at #{default_docker_host}. Is docker running?"

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -114,7 +114,7 @@ module Kitchen
       end
 
       def write_run_command(command)
-        File.write("#{dokken_kitchen_sandbox}/run_command", command)
+        File.write("#{dokken_kitchen_sandbox}/run_command", command, mode: "wb")
       end
 
       def runner_container_name


### PR DESCRIPTION
# Description

Explicitly sets `::Docker.url` from `default_docker_host` rather than relying on the underlying library logic https://github.com/swipely/docker-api/blob/master/lib/docker.rb#L71

Specifies binary file mode when creating `run_command` to suppress EOL CRLF conversion on Windows

## Issues Resolved

#156 #183 #229

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
