### PR TITLE
Pass credentials hash when creating an image

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -600,7 +600,7 @@ module Kitchen
             original_image = Docker::Image.get(path, {}, docker_connection)
           end
 
-          new_image = Docker::Image.create({ "fromImage" => path }, docker_connection)
+          new_image = Docker::Image.create({ "fromImage" => path }, {}, docker_connection)
 
           !(original_image && original_image.id.start_with?(new_image.id))
         end


### PR DESCRIPTION
# Description

The `Docker::Image.create` method expects the credentials as the second argument and the connection as the third argument but this code is wrongly passing the connection in place of the credentials.

## Issues Resolved

Passing the connection like this is causing it to be serialised as the `X-Registry-Auth` header which is then rejected by the server when using podman as the docker daemon.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
