### PR TITLE
Add the slow_resource_report config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,15 @@ driver:
   pull_chef_image: false
 ```
 
+### Testing for Slow Resources in Cookbooks
+
+You can enable the slow resource report at the end of the run in Chef Infra Client 17.2 or later with the `slow_resource_report` config option:
+
+```yaml
+provisioner:
+  slow_resource_report: true
+```
+
 ### Testing without Chef
 
 Containers that supply a no-op binary which returns a successful exit status can be tested without requiring Chef Infra to actually converge.

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -109,6 +109,7 @@ module Kitchen
         cmd << " -c /opt/kitchen/client.rb"
         cmd << " -j /opt/kitchen/dna.json"
         cmd << "--profile-ruby" if config[:profile_ruby]
+        cmd << "--slow-report" if config[:slow_resource_report]
 
         chef_cmd(cmd)
       end


### PR DESCRIPTION
This matches the same change that went into Test Kitchen 2.12

Signed-off-by: Tim Smith <tsmith@chef.io>