### PR TITLE
Add IPv6 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,46 @@ driver:
   hostname_aliases:
     - foo
 ```
+### IPv6 Networking
+
+You can set the `ipv6` parameter to enable IPv6 networking on the `dokken` Docker network. Additionally, the `ipv6_subnet` parameter can be used to determine the subnet the network should use.
+
+```yaml
+driver:
+  name: dokken
+  ipv6: true
+  ipv6_subnet: "2001:db8:1::/64"  # "2001:db8::/32 Range reserved for documentation"
+```
+
+This parameter should be considered a global setting for all dokken containers since dokken does not update the `dokken` network once it's been created. It is *not* recommend to use this parameter within suites.
+
+You can check to see if IPv6 is enabled on the dokken network by seeing if the following command returns `true`:
+
+```bash
+docker network inspect dokken --format='{{.EnableIPv6}}'
+```
+
+If the command returns `false`, we recommend you delete the network and allow dokken to recreate it with IPv6.
+
+To allow IPv6 Docker networks to reach the internet IPv6 firewall rules must be set up. The simplest way to achieve this is to update Docker's `/etc/docker/daemon.json` to use the following settings. You will need to restart the docker daemon after making these changes.
+
+```json
+{
+  "experimental": true,
+  "ip6tables": true
+}
+```
+
+Some containers require the `ip6table_filter` kernel module to be loaded on the host system or ip6tables will not dunction on the container (Centos 7 for example). To check if the module is loaded use the command
+
+```bash
+sudo lsmod | grep ip6table_filter
+```
+
+. If there is no output than the module is not loaded and should be loaded using the command
+```bash
+modprobe ip6table_filter
+```
 
 ## FAQ
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -85,3 +85,9 @@ suites:
   - name: local_image
     includes:
       - local_image
+
+  - name: ipv6
+    includes:
+      - centos
+    driver:
+      ipv6: true

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -50,6 +50,8 @@ module Kitchen
       default_config :hostname, "dokken"
       default_config :hostname_aliases, nil
       default_config :image_prefix, nil
+      default_config :ipv6, false
+      default_config :ipv6_subnet, "2001:db8:1::/64"  # "2001:db8::/32 Range reserved for documentation"
       default_config :links, nil
       default_config :memory_limit, 0
       default_config :network_mode, "dokken"
@@ -359,7 +361,7 @@ module Kitchen
           with_retries { ::Docker::Network.get("dokken", {}, docker_connection) }
         rescue ::Docker::Error::NotFoundError
           begin
-            with_retries { ::Docker::Network.create("dokken", {}) }
+            with_retries { ::Docker::Network.create("dokken", network_settings) }
           rescue ::Docker::Error => e
             debug "driver - error :#{e}:"
           end

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -177,6 +177,21 @@ VOLUME /opt/verifier
       coerce_exposed_ports(config[:ports])
     end
 
+    def network_settings
+      if self[:ipv6]
+        {
+          "EnableIPv6" => true,
+          "IPAM" => {
+            "Config" => [{
+              "Subnet" => self[:ipv6_subnet]
+            }]
+          }
+        }
+      else
+        {}
+      end
+    end
+
     def port_bindings
       coerce_port_bindings(config[:ports])
     end

--- a/test/integration/ipv6/inspec/ipv6_spec.rb
+++ b/test/integration/ipv6/inspec/ipv6_spec.rb
@@ -1,0 +1,3 @@
+describe interface('eth0') do
+  its('ipv6_cidrs') { should include /2001:db8:1::\d\/64/}
+end


### PR DESCRIPTION
# Description

This Adds IPv6 Support to the `dokken` network via the driver config. If the `ipv6` parameter is `true` then the network will enable ipv6 support and use the "2001:db8:1::/64" subnet on the `dokken` network. This subnet can be configured via the `ipv6_subnet` parameter. Documentation is also added in the README.md

## Issues Resolved

None

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable.
