### PR TITLE
Allow a user to specify a specific platform/architecture to use

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -607,10 +607,7 @@ module Kitchen
       end
 
       def chef_container_name
-        if config[:platform] != ""
-          return "chef-#{chef_version}-" + config[:platform].sub("/", "-")
-        end
-        "chef-#{chef_version}"
+        config[:platform] != "" ? "chef-#{chef_version}-" + config[:platform].sub("/", "-") : "chef-#{chef_version}"
       end
 
       def chef_image

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -607,6 +607,9 @@ module Kitchen
       end
 
       def chef_container_name
+        if config[:platform] != ""
+          return "chef-#{chef_version}-" + config[:platform].sub("/", "-")
+        end
         "chef-#{chef_version}"
       end
 


### PR DESCRIPTION
# Description

This is a draft/work-in-process proof of concept to address the idea mentioned in #268 

It allows users to specify either the following in a global config file.

```
---
driver:
  platform: linux/amd64
```

or the following under a specific platform

```
platforms:
  - name: ubuntu-20.04
    driver:
      image: dokken/ubuntu-20.04
      platform: linux/amd64
``` 


## Issues Resolved

#268 

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
