### PR TITLE
check if ~/.docker/config.json exists

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -436,11 +436,15 @@ module Kitchen
 
         @docker_config_creds = {}
         config_file = ::File.join(::Dir.home, ".docker", "config.json")
-        JSON.load_file!(config_file)["auths"].each do |k, v|
-          next if v["auth"].nil?
+        if ::File.exist?(config_file)
+          JSON.load_file!(config_file)["auths"].each do |k, v|
+            next if v["auth"].nil?
 
-          username, password = Base64.decode64(v["auth"]).split(":")
-          @docker_config_creds[k] = { serveraddress: k, username: username, password: password }
+            username, password = Base64.decode64(v["auth"]).split(":")
+            @docker_config_creds[k] = { serveraddress: k, username: username, password: password }
+          end
+        else
+          debug("~/.docker/config.json does not exist")
         end
 
         @docker_config_creds


### PR DESCRIPTION
# Description

Check if ~/.docker/config.json exists before trying to parse credentials.

## Issues Resolved

https://github.com/test-kitchen/kitchen-dokken/pull/262#issuecomment-1177232385

## Type of Change

fix

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
