### PR TITLE
add option to run container with --cgroupns=host

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -38,6 +38,7 @@ module Kitchen
       default_config :binds, []
       default_config :cap_add, nil
       default_config :cap_drop, nil
+      default_config :cgroupns_host, false
       default_config :chef_image, "chef/chef"
       default_config :chef_version, "latest"
       default_config :data_image, "dokken/kitchen-cache:latest"
@@ -329,6 +330,9 @@ module Kitchen
         }
         unless self[:entrypoint].to_s.empty?
           config["Entrypoint"] = self[:entrypoint]
+        end
+        if self[:cgroupns_host]
+          config["HostConfig"]["CgroupnsMode"] = "host"
         end
         if self[:userns_host]
           config["HostConfig"]["UsernsMode"] = "host"


### PR DESCRIPTION
# Description

Docker Desktop 4.3.0+ uses cgroupv2 which breaks containers that use `systemd` ([ref](https://docs.docker.com/desktop/release-notes/#bug-fixes-and-minor-changes-16))

> Containers that use `systemd` need to run with `--privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw.`

This PR provides the ability to do this with a new `cgroupns_host` option in kitchen.yml in the same way that `userns_host` works now.

**kitchen.yml example:**

```
---
driver:
  name: dokken
  privileged: true
  cgroupns_host: true
  volumes:
    - /sys/fs/cgroup:/sys/fs/cgroup:rw
```

## Issues Resolved

- https://github.com/test-kitchen/dokken-images/issues/57 
- https://chefcommunity.slack.com/archives/C2B6G1WCQ/p1658787465367899

## Type of Change

Feature

## Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
