### PR TITLE
Avoid mutating config to fix concurrent execution

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -283,7 +283,7 @@ module Kitchen
 
       def calc_volumes_binds
         volumes = Array.new(Array(config[:volumes]))
-        binds = Array.new(Array(config[:binds])) 
+        binds = Array.new(Array(config[:binds]))
 
         # Binds is mutated in-place, volumes *may* be.
         volumes = coerce_volumes(volumes, binds)
@@ -293,7 +293,7 @@ module Kitchen
         binds_ret << "#{dokken_verifier_sandbox}:/opt/verifier" unless dokken_verifier_sandbox.nil? || remote_docker_host? || running_inside_docker?
         binds_ret << binds unless binds.nil?
 
-        return volumes, binds_ret.flatten
+        [volumes, binds_ret.flatten]
       end
 
       def start_runner_container(state)

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -236,20 +236,8 @@ module Kitchen
         instance_name
       end
 
-      def dokken_binds
-        ret = []
-        ret << "#{dokken_kitchen_sandbox}:/opt/kitchen" unless dokken_kitchen_sandbox.nil? || remote_docker_host?
-        ret << "#{dokken_verifier_sandbox}:/opt/verifier" unless dokken_verifier_sandbox.nil? || remote_docker_host?
-        ret << Array(config[:binds]) unless config[:binds].nil?
-        ret.flatten
-      end
-
       def dokken_tmpfs
         coerce_tmpfs(config[:tmpfs])
-      end
-
-      def dokken_volumes
-        coerce_volumes(config[:volumes])
       end
 
       def coerce_tmpfs(v)
@@ -264,27 +252,6 @@ module Kitchen
         end
       end
 
-      def coerce_volumes(v)
-        case v
-        when PartialHash, nil
-          v
-        when Hash
-          PartialHash[v]
-        else
-          b = []
-          v = Array(v).to_a # in case v.is_A?(Chef::Node::ImmutableArray)
-          v.delete_if do |x|
-            parts = x.split(":")
-            b << x if parts.length > 1
-          end
-          b = nil if b.empty?
-          config[:binds].push(b) unless config[:binds].include?(b) || b.nil?
-          return PartialHash.new if v.empty?
-
-          v.each_with_object(PartialHash.new) { |volume, h| h[volume] = {} }
-        end
-      end
-
       def dokken_volumes_from
         ret = []
         ret << chef_container_name
@@ -292,8 +259,45 @@ module Kitchen
         ret
       end
 
+      def coerce_volumes(v, binds)
+        case v
+        when PartialHash, nil
+          v
+        when Hash
+          PartialHash[v]
+        else
+          b = []
+          v.delete_if do |x|
+            parts = x.split(":")
+            b << x if parts.length > 1
+          end
+          b = nil if b.empty?
+          binds.push(b) unless binds.include?(b) || b.nil?
+          return PartialHash.new if v.empty?
+
+          v.each_with_object(PartialHash.new) { |volume, h| h[volume] = {} }
+        end
+      end
+
+      def calc_volumes_binds
+        volumes = Array.new(Array(config[:volumes]))
+        binds = Array.new(Array(config[:binds])) 
+
+        # Binds is mutated in-place, volumes *may* be.
+        volumes = coerce_volumes(volumes, binds)
+
+        binds_ret = []
+        binds_ret << "#{dokken_kitchen_sandbox}:/opt/kitchen" unless dokken_kitchen_sandbox.nil? || remote_docker_host?
+        binds_ret << "#{dokken_verifier_sandbox}:/opt/verifier" unless dokken_verifier_sandbox.nil? || remote_docker_host?
+        binds_ret << binds unless binds.nil?
+
+        return volumes, binds_ret.flatten
+      end
+
       def start_runner_container(state)
         debug "driver - starting #{runner_container_name}"
+
+        volumes, binds = calc_volumes_binds
 
         config = {
           "name" => runner_container_name,
@@ -303,11 +307,11 @@ module Kitchen
           "Hostname" => self[:hostname],
           "Env" => self[:env],
           "ExposedPorts" => exposed_ports,
-          "Volumes" => dokken_volumes,
+          "Volumes" => volumes,
           "HostConfig" => {
             "Privileged" => self[:privileged],
             "VolumesFrom" => dokken_volumes_from,
-            "Binds" => dokken_binds,
+            "Binds" => binds,
             "Dns" => self[:dns],
             "DnsSearch" => self[:dns_search],
             "Links" => Array(self[:links]),


### PR DESCRIPTION
# Description

It seems that Kitchen does not provide separate objects in all cases when doing concurrent execution. This means that mutating config[:binds] and config[:volumes] caused inconsistent state in concurrent actions.

We now copy these before mutating to avoid this.

## Issues Resolved

I couldn't find any issues and just decided to fix it right away.

## Type of Change

Just a fix

<!-- Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge. -->

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
