### PR TITLE
feat: add support for running dokken in a container

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -91,7 +91,7 @@ module Kitchen
         # data
         dokken_create_sandbox
 
-        if remote_docker_host?
+        if remote_docker_host? || running_inside_docker?
           make_data_image
           start_data_container state
         end
@@ -107,7 +107,7 @@ module Kitchen
       end
 
       def destroy(_state)
-        if remote_docker_host?
+        if remote_docker_host? || running_inside_docker?
           stop_data_container
           delete_data_container
         end
@@ -240,8 +240,8 @@ module Kitchen
 
       def dokken_binds
         ret = []
-        ret << "#{dokken_kitchen_sandbox}:/opt/kitchen" unless dokken_kitchen_sandbox.nil? || remote_docker_host?
-        ret << "#{dokken_verifier_sandbox}:/opt/verifier" unless dokken_verifier_sandbox.nil? || remote_docker_host?
+        ret << "#{dokken_kitchen_sandbox}:/opt/kitchen" unless dokken_kitchen_sandbox.nil? || remote_docker_host? || running_inside_docker?
+        ret << "#{dokken_verifier_sandbox}:/opt/verifier" unless dokken_verifier_sandbox.nil? || remote_docker_host? || running_inside_docker?
         ret << Array(config[:binds]) unless config[:binds].nil?
         ret.flatten
       end
@@ -290,7 +290,7 @@ module Kitchen
       def dokken_volumes_from
         ret = []
         ret << chef_container_name
-        ret << data_container_name if remote_docker_host?
+        ret << data_container_name if remote_docker_host? || running_inside_docker?
         ret
       end
 

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -340,11 +340,11 @@ module Kitchen
         end
 
         if self[:privileged]
-          if self[:user_ns_mode] != 'host'
+          if self[:user_ns_mode] != "host"
             debug "driver - privileged mode is not supported with user namespaces enabled"
             debug "driver - changing UsernsMode from '#{self[:user_ns_mode]}' to 'host'"
           end
-          config['HostConfig']['UsernsMode'] = 'host'
+          config["HostConfig"]["UsernsMode"] = "host"
         end
 
         runner_container = run_container(config)

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -268,7 +268,7 @@ module Dokken
 
       false
     end
-    
+
     def running_inside_docker?
       File.file?("/.dockerenv")
     end

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -3,6 +3,7 @@ module Dokken
     # https://stackoverflow.com/questions/517219/ruby-see-if-a-port-is-open
     require "socket" unless defined?(Socket)
     require "timeout" unless defined?(Timeout)
+    require "resolv" unless defined?(Resolv)
 
     def port_open?(ip, port)
       begin
@@ -265,6 +266,17 @@ module Dokken
       return false if config[:docker_info]["OperatingSystem"].include?("Boot2Docker")
       return true if /^tcp:/.match?(config[:docker_host_url])
 
+      false
+    end
+    
+    def running_inside_docker?
+      File.file?("/.dockerenv")
+    end
+
+    def running_inside_docker_desktop?
+      Resolv.getaddress "host.docker.internal."
+      true
+    rescue
       false
     end
 

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -58,7 +58,7 @@ module Kitchen
         create_sandbox
         write_run_command(run_command)
         instance.transport.connection(state) do |conn|
-          if remote_docker_host?
+          if remote_docker_host? || running_inside_docker?
             info("Transferring files to #{instance.to_str}")
             conn.upload(sandbox_dirs, config[:root_path])
           end

--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -93,8 +93,8 @@ module Kitchen
 
           elsif /unix:/.match?(options[:docker_host_url])
             if options[:data_container][:NetworkSettings][:Ports][:"22/tcp"][0][:HostIp] == "0.0.0.0"
-                ssh_ip = options[:data_container][:NetworkSettings][:IPAddress]
-                ssh_port = "22"
+              ssh_ip = options[:data_container][:NetworkSettings][:IPAddress]
+              ssh_port = "22"
             else
               # we should read the proper mapped ip, since this allows us to upload the files
               ssh_ip = options[:data_container][:NetworkSettings][:Ports][:"22/tcp"][0][:HostIp]


### PR DESCRIPTION
# Description

When kitchen-dokken is run inside docker itself with the socket mounted in it fails for a number of reasons:
- Kitchen dokken will write files within $HOME/.dokken within the _container_, then attempt to bind bind that into the container being converged. Because bind mounts mount files/folders from the _host_ this will cause failure.
- If the docker instance is a docker-desktop instance (for example Docker for Mac) then the transport will resolve the incorrect address for the ssh connection

This change causes dokken to detect when it is run inside docker, and if it is it will aways use a data container. It will also connect to the data container using the internal "host.docker.internal" address if it detects the docker instance it is running is is a docker-desktop instance. 

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
