### PR TITLE
Release 2.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dokken Changelog
 
+## 2.17.4 (2022-12-20)
+
+- Add option to run container with --cgroupns=host [@drewhammond](https://github.com/drewhammond)
+
 ## 2.17.3 (2022-07-20)
 
 - check if ~/.docker/config.json file exists [@evandam](https://github.com/evandam)

--- a/lib/kitchen/driver/dokken_version.rb
+++ b/lib/kitchen/driver/dokken_version.rb
@@ -18,6 +18,6 @@
 module Kitchen
   module Driver
     # Version string for Dokken Kitchen driver
-    DOKKEN_VERSION = "2.17.3".freeze
+    DOKKEN_VERSION = "2.17.4".freeze
   end
 end


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

# Description

Release 2.17.4
- Add option to run container with --cgroupns=host [@drewhammond](https://github.com/drewhammond)

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
