### PR TITLE
Restore attempt to read config.json for registry auth

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -663,7 +663,7 @@ module Kitchen
             original_image = Docker::Image.get(path, { "platform" => config[:platform] }, docker_connection)
           end
 
-          new_image = Docker::Image.create({ "fromImage" => path, "platform" => config[:platform] }, docker_creds, docker_connection)
+          new_image = Docker::Image.create({ "fromImage" => path, "platform" => config[:platform] }, docker_creds_for_image(image), docker_connection)
 
           !(original_image && original_image.id.start_with?(new_image.id))
         end


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

# Description

While adding the support for different platforms/architecture in #272, some code fragments were removed accidentally
which causes the automatic reading of the `~/.docker/config.json` file to attempt the registry auth. 

This PR will revert those changes and will restore the functionality back. 

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
