### PR TITLE
feat: use docker credential helpers to get auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,52 @@ And the `creds.json` file may look like this:
 }
 ```
 
+### Docker config file auth
+
+Instead of using a `creds_file`, you can read authentication information from your docker config at `~/.docker/config.json`
+
+```yaml
+platforms:
+  - name: centos-7
+    driver:
+      image: quay.io/example/centos:7
+      docker_config_creds: true
+```
+
+And your `~/.docker/config.json` would have an auth section for your private registry:
+
+```json
+{
+  "auths": {
+    "quay.io": {
+      "auth": "<base64 encoded username:password>"
+    }
+  }
+}
+```
+
+Additionally, you can use [Docker credential helpers](https://docs.docker.com/engine/reference/commandline/login/#credential-helpers)
+
+```yaml
+platforms:
+  - name: centos-7
+    driver:
+      image: 1234-cloud-registry.example.com/centos:7
+      docker_config_creds: true
+```
+
+and your docker config has
+
+```json
+{
+  "credHelpers": {
+    "1234-cloud-registry.example.com": "example-cloud"
+  }
+}
+```
+
+Then `kitchen-dokken` will run the `docker-credential-example-cloud` command to get the credentials.
+
 ## FAQ
 
 ### What about kitchen-docker?

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -441,11 +441,23 @@ module Kitchen
         @docker_config_creds = {}
         config_file = ::File.join(::Dir.home, ".docker", "config.json")
         if ::File.exist?(config_file)
-          JSON.load_file!(config_file)["auths"].each do |k, v|
-            next if v["auth"].nil?
+          config = JSON.load_file!(config_file)
+          if config["auths"]
+            config["auths"].each do |k, v|
+              next if v["auth"].nil?
 
-            username, password = Base64.decode64(v["auth"]).split(":")
-            @docker_config_creds[k] = { serveraddress: k, username: username, password: password }
+              username, password = Base64.decode64(v["auth"]).split(":")
+              @docker_config_creds[k] = { serveraddress: k, username: username, password: password }
+            end
+          end
+
+          if config["credHelpers"]
+            config["credHelpers"].each do |k, v|
+              @docker_config_creds[k] = Proc.new do
+                c = JSON.parse(`echo #{k} | docker-credential-#{v} get`)
+                { serveraddress: c["ServerURL"], username: c["Username"], password: c["Secret"] }
+              end
+            end
           end
         else
           debug("~/.docker/config.json does not exist")
@@ -462,7 +474,8 @@ module Kitchen
         # NOTE: Try to use DockerHub auth if exact registry match isn't found
         default_registry = "https://index.docker.io/v1/"
         if docker_config_creds.key?(image_registry)
-          docker_config_creds[image_registry]
+          c = docker_config_creds[image_registry]
+          c.respond_to?(:call) ? c.call : c
         elsif docker_config_creds.key?(default_registry)
           docker_config_creds[default_registry]
         end


### PR DESCRIPTION
# Description

When using `docker_config_creds: true` this will use any [docker credential helpers](https://docs.docker.com/engine/reference/commandline/login/#credential-helpers) defined in `~/.docker/config.json`

In particular this makes it possible to use the [AWS ECR Docker Credential Helper](https://github.com/awslabs/amazon-ecr-credential-helper) to pull images from private ECR registries

## Issues Resolved

This is related to the work I did ages ago on PR #189 and builds on #262

## Type of Change

I would say this is a new feature.

## Check List

- [x] ~New functionality includes tests~
- [x] ~All tests pass~
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)

note that there aren't any tests for the other features around docker credentials.