### PR TITLE
fix: do not set network aliases for host or bridge networks

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -84,3 +84,11 @@ suites:
       - centos
     driver:
       ipv6: true
+
+  - name: bridge
+    driver:
+      network_mode: bridge
+
+  - name: host
+    driver:
+      network_mode: host

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -321,14 +321,16 @@ module Kitchen
             "Tmpfs" => dokken_tmpfs,
             "Memory" => self[:memory_limit],
           },
-          "NetworkingConfig" => {
+        }
+        unless %w{host bridge}.include?(self[:network_mode])
+          config["NetworkingConfig"] = {
             "EndpointsConfig" => {
               self[:network_mode] => {
                 "Aliases" => Array(self[:hostname]).concat(Array(self[:hostname_aliases])),
               },
             },
-          },
-        }
+          }
+        end
         unless self[:entrypoint].to_s.empty?
           config["Entrypoint"] = self[:entrypoint]
         end
@@ -362,19 +364,23 @@ module Kitchen
             "PublishAllPorts" => true,
             "NetworkMode" => "bridge",
           },
-          "NetworkingConfig" => {
+        }
+        unless %w{host bridge}.include?(self[:network_mode])
+          config["NetworkingConfig"] = {
             "EndpointsConfig" => {
               self[:network_mode] => {
                 "Aliases" => Array(self[:hostname]),
               },
             },
-          },
-        }
+          }
+        end
         data_container = run_container(config)
         state[:data_container] = data_container.json
       end
 
       def make_dokken_network
+        return unless self[:network_mode] == "dokken"
+
         lockfile = Lockfile.new "#{home_dir}/.dokken-network.lock"
         begin
           lockfile.lock


### PR DESCRIPTION
# Description

Allows the `network_mode` setting to be a pre-defined network (such as `bridge` or `host`).

Without this, when the network mode is set to `host` or `bridge`, you get this error:

```
Failed to complete #create action: [{"message":"network-scoped alias is supported only for containers in user defined networks"}] on host-hello
```

Also, don't bother creating the `dokken` network if the `network_mode` is set to something else.

## Type of Change

Fix

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
