### PR TITLE
fix: Use default registry credentials when they are set

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -495,7 +495,8 @@ module Kitchen
           c = docker_config_creds[image_registry]
           c.respond_to?(:call) ? c.call : c
         elsif docker_config_creds.key?(default_registry)
-          docker_config_creds[default_registry]
+          c = docker_config_creds[default_registry]
+          c.respond_to?(:call) ? c.call : c
         end
       end
 


### PR DESCRIPTION
# Description
This allows credentials for the default index to be used. In our case we have the business version of docker hub and get a 407 proxy error when we don't use user/pass via PAT token to auth to docker. As such we store the creds and this fix allows that situation to work.

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
