### PR TITLE
fix failed run exit code when clean_dokken_sandbox is false

### DIFF
--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -74,9 +74,7 @@ module Kitchen
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message
       ensure
-        return unless config[:clean_dokken_sandbox] # rubocop: disable Lint/EnsureReturn
-
-        cleanup_dokken_sandbox
+        cleanup_dokken_sandbox if config[:clean_dokken_sandbox] # rubocop: disable Lint/EnsureReturn
       end
 
       def validate_config


### PR DESCRIPTION
# Description

If clean_dokken_sandbox provisioner option is set to false, `kitchen converge` always exits with exit code 0 even if the chef-client run fails convergence. This is due to the return negating the exception that was raised.

## Issues Resolved

#318 

## Type of Change

bug fix

## Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
