### PR TITLE
fix: Use configured host URL when fetching docker information (#321)

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -45,7 +45,9 @@ module Kitchen
       default_config :dns, nil
       default_config :dns_search, nil
       default_config :docker_host_url, default_docker_host
-      default_config :docker_info, docker_info
+      default_config :docker_info do |driver|
+        docker_info(driver[:docker_host_url])
+      end
       default_config :docker_registry, nil
       default_config :entrypoint, nil
       default_config :env, nil

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -117,8 +117,8 @@ module Dokken
       end
     end
 
-    def docker_info
-      ::Docker.url = default_docker_host
+    def docker_info(docker_host)
+      ::Docker.url = docker_host
 
       @docker_info ||= ::Docker.info
     rescue Excon::Error::Socket

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -35,7 +35,9 @@ module Kitchen
       default_config :chef_log_level, "warn"
       default_config :chef_output_format, "doc"
       default_config :profile_ruby, false
-      default_config :docker_info, docker_info
+      default_config :docker_info do |provisioner|
+        docker_info(provisioner[:docker_host_url])
+      end
       default_config :docker_host_url, default_docker_host
 
       # Dokken is weird - the provisioner inherits from ChefZero but does not install

--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -39,7 +39,9 @@ module Kitchen
 
       plugin_version Kitchen::VERSION
 
-      default_config :docker_info, docker_info
+      default_config :docker_info do |transport|
+        docker_info(transport[:docker_host_url])
+      end
       default_config :docker_host_url, default_docker_host
       default_config :read_timeout, 3600
       default_config :write_timeout, 3600


### PR DESCRIPTION
# Description

Uses the correct docker host URL when fetching docker information if the configuration has overridden the default host URL.

## Issues Resolved

Fixes #321.

## Type of Change

Fix.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
