### PR TITLE
fix: Switch to using AlmaLinux 9 for the data container

### DIFF
--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -58,7 +58,7 @@ module Dokken
     end
 
     def data_dockerfile(registry)
-      from = "centos:7"
+      from = "almalinux:9"
       if registry
         from = "#{registry}/#{from}"
       end
@@ -67,7 +67,7 @@ module Dokken
         MAINTAINER Sean OMeara "sean@sean.io"
         ENV LANG en_US.UTF-8
 
-        RUN yum -y install tar rsync openssh-server passwd git
+        RUN dnf -y install tar rsync openssh-server passwd git
         RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
 
         # uncomment to debug cert issues


### PR DESCRIPTION
CentOS 7 was EOL yesterday and this is breaking all dokken workflows.

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Please describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
