### PR TITLE
_fix_: correct start of data container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dokken Changelog
 
+### Bug Fixes
+
+## [2.20.7](https://github.com/test-kitchen/kitchen-dokken/compare/v2.20.6...v2.20.7) (2024-07-02)
+
 ## [2.20.6](https://github.com/test-kitchen/kitchen-dokken/compare/v2.20.5...v2.20.6) (2024-07-01)
 
 

--- a/lib/kitchen/driver/dokken_version.rb
+++ b/lib/kitchen/driver/dokken_version.rb
@@ -18,6 +18,6 @@
 module Kitchen
   module Driver
     # Version string for Dokken Kitchen driver
-    DOKKEN_VERSION = "2.20.6".freeze
+    DOKKEN_VERSION = "2.20.7".freeze
   end
 end

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -81,7 +81,7 @@ module Dokken
         RUN chmod 600  /root/.ssh/authorized_keys
 
         EXPOSE 22
-        CMD [ "/usr/sbin/sshd", "-D", "-p", "22", "-o", "UseDNS=no", "-o", "UsePrivilegeSeparation=no", "-o", "MaxAuthTries=60" ]
+        CMD [ "/usr/sbin/sshd", "-D", "-p", "22", "-o", "UseDNS=no", "-o", "MaxAuthTries=60" ]
 
         VOLUME /opt/kitchen
         VOLUME /opt/verifier


### PR DESCRIPTION
# Description

Following the update to recent image [PR 330](https://github.com/test-kitchen/kitchen-dokken/pull/330) the `data` container won't start due to [deprecation](https://www.openssh.com/txt/release-7.5) of `UsePrivilegeSeparation` option:
```
This release includes a number of changes that may affect existing
configurations:

 * This release deprecates the sshd_config UsePrivilegeSeparation
   option, thereby making privilege separation mandatory. Privilege
   separation has been on by default for almost 15 years and
   sandboxing has been on by default for almost the last five.
```

## Issues Resolved

`UsePrivilegeSeparation` option removed, container starts.

## Type of Change

Fix.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
