### PR TITLE
Hab based installation of chef-infra-client

### DIFF
--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -31,6 +31,7 @@ module Kitchen
 
       default_config :root_path, "/opt/kitchen"
       default_config :chef_binary, "/opt/chef/bin/chef-client"
+      default_config :hab_chef_binary, "/hab/hab_bin"
       default_config :chef_options, " -z"
       default_config :chef_log_level, "warn"
       default_config :chef_output_format, "doc"
@@ -102,14 +103,15 @@ module Kitchen
       # patching Kitchen::Provisioner::ChefZero#run_command
       def run_command
         validate_config
-        cmd = config[:chef_binary]
+        cmd = chef_executable
         cmd << config[:chef_options].to_s
         cmd << " -l #{config[:chef_log_level]}"
         cmd << " -F #{config[:chef_output_format]}"
         cmd << " -c /opt/kitchen/client.rb"
         cmd << " -j /opt/kitchen/dna.json"
-        cmd << "--profile-ruby" if config[:profile_ruby]
-        cmd << "--slow-report" if config[:slow_resource_report]
+        cmd << " --profile-ruby" if config[:profile_ruby]
+        cmd << " --slow-report" if config[:slow_resource_report]
+        cmd << " --chef-license-key=#{config[:chef_license_key]}" if instance.driver.installer == "habitat" && config[:chef_license_key]
 
         chef_cmd(cmd)
       end
@@ -127,6 +129,12 @@ module Kitchen
 
         debug("Cleaning up local sandbox in #{sandbox_path}")
         FileUtils.rmtree(Dir.glob("#{sandbox_path}/*"))
+      end
+
+      def chef_executable
+        return "HAB_LICENSE='accept-no-persist' #{config[:hab_chef_binary]} pkg exec ashiqueps/chef-infra-client -- chef-client " if instance.driver.installer == "habitat"
+
+        "#{config[:chef_binary]}"
       end
     end
   end


### PR DESCRIPTION
# Description

This PR add the following:

- By default, the chef/chef-habitat image will be used to setup chef-infra-client, which will be using the habitat-based installation.
- If the user needs, he can setup a flag in kitchen.yml file to use the chef/chef docker image which is an omnibus version of the chef infra client. Note that in this option, infra 19 will not be available. 

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
