### PR TITLE
fix: provisioner root_path config option

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -287,7 +287,7 @@ module Kitchen
         volumes = coerce_volumes(volumes, binds)
 
         binds_ret = []
-        binds_ret << "#{dokken_kitchen_sandbox}:/opt/kitchen" unless dokken_kitchen_sandbox.nil? || remote_docker_host? || running_inside_docker?
+        binds_ret << "#{dokken_kitchen_sandbox}:#{resolved_root_path}" unless dokken_kitchen_sandbox.nil? || remote_docker_host? || running_inside_docker?
         binds_ret << "#{dokken_verifier_sandbox}:/opt/verifier" unless dokken_verifier_sandbox.nil? || remote_docker_host? || running_inside_docker?
         binds_ret << binds unless binds.nil?
 

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -83,7 +83,7 @@ module Dokken
         EXPOSE 22
         CMD [ "/usr/sbin/sshd", "-D", "-p", "22", "-o", "UseDNS=no", "-o", "UsePrivilegeSeparation=no", "-o", "MaxAuthTries=60" ]
 
-        VOLUME /opt/kitchen
+        VOLUME #{resolved_root_path}
         VOLUME /opt/verifier
       EOF
     end
@@ -293,6 +293,10 @@ module Dokken
       unless ::Dir.exist?(sandbox_path)
         FileUtils.mkdir_p(sandbox_path, mode: 0o755)
       end
+    end
+
+    def resolved_root_path
+      instance.provisioner[:root_path] || "/opt/kitchen"
     end
   end
 end

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -104,8 +104,8 @@ module Kitchen
         cmd << config[:chef_options].to_s
         cmd << " -l #{config[:chef_log_level]}"
         cmd << " -F #{config[:chef_output_format]}"
-        cmd << " -c /opt/kitchen/client.rb"
-        cmd << " -j /opt/kitchen/dna.json"
+        cmd << " -c #{File.join(config[:root_path], "client.rb")}"
+        cmd << " -j #{File.join(config[:root_path], "dna.json")}"
         cmd << "--profile-ruby" if config[:profile_ruby]
         cmd << "--slow-report" if config[:slow_resource_report]
 


### PR DESCRIPTION
# Description

Fixed provisioner `root_path` configuration variable to change hardcoded paths.

All other kitchen drivers default to `/tmp/kitchen` it's harder to adapt cookbooks to allow for testing using `kitchen-dokken` when a default path changes to `/opt/kitchen` (escpecially when testing same cookbooks with both drivers), any idea/reason why it was changed to `/opt/kitchen` to begin with, maybe it should match other drivers for consistency?

## Issues Resolved

Currently, setting `root_path` to anything else other than default value of `/tmp/kitchen` will fail as there's multiple hardcoded paths to `/opt/kitchen`

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
